### PR TITLE
Use set_request_property instead of subscriber to improve performance

### DIFF
--- a/pyramid_mongodb/__init__.py
+++ b/pyramid_mongodb/__init__.py
@@ -11,13 +11,13 @@ simplified mongodb integration
         python_mongodb.initialize_mongo_db( config , settings )
         ## ...
         return config.make_wsgi_app()
-	
+
 2. in each of your envinronment.ini files, have:
 
     mongodb.use = true
     mongodb.uri = mongodb://localhost
     mongodb.name = myapp
-    
+
 if "mongodb.use" is not "true", then it won't be configured -- so you can do your local development / tests / etc without having mongodb running ( should you want to )
 
 """
@@ -25,15 +25,15 @@ import pymongo
 from gridfs import GridFS
 
 
-def initialize_mongo_db( config, settings ):
-    if ( 'mongodb.use' in settings ) and ( settings['mongodb.use'] == 'true' ):
-        conn = pymongo.Connection( settings['mongodb.uri'] )
+def initialize_mongo_db(config, settings):
+    if ('mongodb.use' in settings) and (settings['mongodb.use'] == 'true'):
+        conn = pymongo.Connection(settings['mongodb.uri'])
         config.registry.settings['!mongodb.conn'] = conn
-        config.add_subscriber(add_mongo_db, 'pyramid.events.NewRequest')
+        config.set_request_property(add_mongo_db, 'mongodb', reify=True)
 
 
-def add_mongo_db(event):
-    settings = event.request.registry.settings
+def add_mongo_db(request):
+    settings = request.registry.settings
     db = settings['!mongodb.conn'][settings['mongodb.name']]
-    event.request.mongodb = db
-    event.request.gridfs = GridFS(db)
+    request.mongodb = db
+    request.gridfs = GridFS(db)


### PR DESCRIPTION
According to https://github.com/Pylons/pyramid_cookbook/blob/master/auth/user_object.rst

`add_subscriber` cause connect to db even in serving static file.
`set_request_property` only make add_mongo_db be called when you access the property, `mongodb` here.
For Pyramid 1.4, use `add_request_method` should be better. But I don't know whether this package support 1.4 or not.
