### PR TITLE
Re-enable chameleon templates

### DIFF
--- a/pyramid_mongodb/paster_templates/pyramid_mongodb/+package+/__init__.py_tmpl
+++ b/pyramid_mongodb/paster_templates/pyramid_mongodb/+package+/__init__.py_tmpl
@@ -9,6 +9,7 @@ def main(global_config, **settings):
     """ This function returns a WSGI application.
     """
     config = Configurator(settings=settings, root_factory=Root)
+    config.include('pyramid_chameleon')
     config.add_view('{{package}}.views.my_view',
                     context='{{package}}:resources.Root',
                     renderer='{{package}}:templates/mytemplate.pt')


### PR DESCRIPTION
Re-enable chameleon templates through the pyramid_chameleon add-on (required for Pyramid 1.5+)
