### PR TITLE
docs: Fix simple typo, envinronment -> environment

### DIFF
--- a/pyramid_mongodb/__init__.py
+++ b/pyramid_mongodb/__init__.py
@@ -12,7 +12,7 @@ simplified mongodb integration
         ## ...
         return config.make_wsgi_app()
 
-2. in each of your envinronment.ini files, have:
+2. in each of your environment.ini files, have:
 
     mongodb.use = true
     mongodb.uri = mongodb://localhost


### PR DESCRIPTION
There is a small typo in pyramid_mongodb/__init__.py.

Should read `environment` rather than `envinronment`.

